### PR TITLE
refactor(pkg): move Provider model to common package

### DIFF
--- a/pkg/common/provider.go
+++ b/pkg/common/provider.go
@@ -1,0 +1,8 @@
+package common
+
+type Provider string
+
+const (
+	GCP Provider = "GCP"
+	AWS Provider = "AWS"
+)

--- a/pkg/storage/aws/aws.go
+++ b/pkg/storage/aws/aws.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"synkronus/pkg/common"
 	"synkronus/pkg/storage"
 	"time"
 )
@@ -19,8 +20,8 @@ func NewAWSStorage(region string) *AWSStorage {
 	}
 }
 
-func (s *AWSStorage) ProviderName() storage.Provider {
-	return storage.AWS
+func (s *AWSStorage) ProviderName() common.Provider {
+	return common.AWS
 }
 
 func (s *AWSStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
@@ -29,7 +30,7 @@ func (s *AWSStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) 
 	return []storage.Bucket{
 		{
 			Name:         "example-bucket-1",
-			Provider:     storage.AWS,
+			Provider:     common.AWS,
 			Location:     s.region,
 			StorageClass: "STANDARD",
 			CreatedAt:    time.Date(2025, 1, 10, 8, 15, 0, 0, time.UTC),
@@ -37,7 +38,7 @@ func (s *AWSStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) 
 		},
 		{
 			Name:         "example-bucket-2",
-			Provider:     storage.AWS,
+			Provider:     common.AWS,
 			Location:     s.region,
 			StorageClass: "GLACIER",
 			CreatedAt:    time.Date(2024, 5, 20, 14, 0, 0, 0, time.UTC),
@@ -51,7 +52,7 @@ func (s *AWSStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 
 	return storage.Bucket{
 		Name:         bucketName,
-		Provider:     storage.AWS,
+		Provider:     common.AWS,
 		Location:     s.region,
 		StorageClass: "STANDARD",
 		CreatedAt:    time.Date(2025, 1, 10, 8, 15, 0, 0, time.UTC),

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"synkronus/pkg/common"
 	"time"
 
 	"synkronus/pkg/storage"
@@ -34,8 +35,8 @@ func NewGCPStorage(ctx context.Context, projectID string) (*GCPStorage, error) {
 	}, nil
 }
 
-func (g *GCPStorage) ProviderName() storage.Provider {
-	return storage.GCP
+func (g *GCPStorage) ProviderName() common.Provider {
+	return common.GCP
 }
 
 func (g *GCPStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) {
@@ -68,7 +69,7 @@ func (g *GCPStorage) ListBuckets(ctx context.Context) ([]storage.Bucket, error) 
 
 		buckets = append(buckets, storage.Bucket{
 			Name:         bucketAttrs.Name,
-			Provider:     storage.GCP,
+			Provider:     common.GCP,
 			Location:     bucketAttrs.Location,
 			StorageClass: bucketAttrs.StorageClass,
 			CreatedAt:    bucketAttrs.Created,
@@ -151,7 +152,7 @@ func (g *GCPStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 
 	details := storage.Bucket{
 		Name:         attrs.Name,
-		Provider:     storage.GCP,
+		Provider:     common.GCP,
 		Location:     attrs.Location,
 		StorageClass: attrs.StorageClass,
 		CreatedAt:    attrs.Created,

--- a/pkg/storage/model.go
+++ b/pkg/storage/model.go
@@ -2,19 +2,13 @@ package storage
 
 import (
 	"fmt"
+	"synkronus/pkg/common"
 	"time"
-)
-
-type Provider string
-
-const (
-	GCP Provider = "GCP"
-	AWS Provider = "AWS"
 )
 
 type Bucket struct {
 	Name         string
-	Provider     Provider
+	Provider     common.Provider
 	Location     string
 	StorageClass string
 	CreatedAt    time.Time

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,13 +1,17 @@
+// File: pkg/storage/storage.go
 package storage
 
-import "context"
+import (
+	"context"
+	"synkronus/pkg/common"
+)
 
 type Storage interface {
 	ListBuckets(ctx context.Context) ([]Bucket, error)
 
 	DescribeBucket(ctx context.Context, bucketName string) (Bucket, error)
 
-	ProviderName() Provider
+	ProviderName() common.Provider
 
 	Close() error
 }


### PR DESCRIPTION
Refactors the location of the core Provider model to avoid creating illogical dependencies between service packages