### PR TITLE
refactor: improve error handling & concurrency robustness

### DIFF
--- a/cmd/synkronus/config_cmd.go
+++ b/cmd/synkronus/config_cmd.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"synkronus/internal/config"
@@ -19,15 +18,15 @@ var configSetCmd = &cobra.Command{
 	Short: "Set a configuration key-value pair",
 	Long:  `Sets a configuration value. For example: 'synkronus config set gcp_project my-gcp-123'`,
 	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		key := args[0]
 		value := args[1]
 
 		if err := config.SetValue(key, value); err != nil {
-			fmt.Printf("Error setting configuration: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("error setting configuration: %v", err)
 		}
 		fmt.Printf("Configuration set: %s = %s\n", key, value)
+		return nil
 	},
 }
 
@@ -36,20 +35,19 @@ var configGetCmd = &cobra.Command{
 	Short: "Get a configuration value by key",
 	Long:  `Retrieves a configuration value for a given key.`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		key := args[0]
 		value, exists, err := config.GetValue(key)
 
 		if err != nil {
-			fmt.Printf("Error getting configuration: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("error getting configuration: %v", err)
 		}
 
 		if !exists {
-			fmt.Printf("Configuration key '%s' not found\n", key)
-			os.Exit(1)
+			return fmt.Errorf("configuration key '%s' not found", key)
 		}
 		fmt.Printf("%s = %v\n", key, value)
+		return nil
 	},
 }
 
@@ -58,20 +56,19 @@ var configDeleteCmd = &cobra.Command{
 	Short: "Delete a configuration value by key",
 	Long:  `Deletes a configuration value for a given key.`,
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		key := args[0]
 		deleted, err := config.DeleteValue(key)
 
 		if err != nil {
-			fmt.Printf("Error deleting configuration: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("error deleting configuration: %v", err)
 		}
 
 		if !deleted {
-			fmt.Printf("Configuration key '%s' not found\n", key)
-			os.Exit(1)
+			return fmt.Errorf("configuration key '%s' not found", key)
 		}
 		fmt.Printf("Configuration key '%s' deleted\n", key)
+		return nil
 	},
 }
 
@@ -79,22 +76,22 @@ var configListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all current configuration values",
 	Long:  `Displays all the key-value pairs currently stored in the configuration.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		configValues, err := config.ListValues()
 		if err != nil {
-			fmt.Printf("Error listing configuration: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("error listing configuration: %v", err)
 		}
 
 		if len(configValues) == 0 {
 			fmt.Println("No configuration values set")
-			return
+			return nil
 		}
 
 		fmt.Println("Current configuration:")
 		for key, value := range configValues {
 			fmt.Printf("  %s = %v\n", key, value)
 		}
+		return nil
 	},
 }
 

--- a/cmd/synkronus/sql_cmd.go
+++ b/cmd/synkronus/sql_cmd.go
@@ -16,9 +16,10 @@ var sqlCmd = &cobra.Command{
 var sqlListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List SQL resources",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Listing SQL resources...")
 		// TODO: Implement SQL listing functionality
+		return nil
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// File: go.mod
 module synkronus
 
 go 1.23.0
@@ -8,6 +9,7 @@ require (
 	cloud.google.com/go/monitoring v1.21.2
 	cloud.google.com/go/storage v1.50.0
 	github.com/spf13/cobra v1.8.1
+	golang.org/x/sync v0.11.0
 	google.golang.org/api v0.223.0
 	google.golang.org/protobuf v1.36.5
 )
@@ -50,7 +52,6 @@ require (
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
-	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.10.0 // indirect


### PR DESCRIPTION
Refactors all Cobra commands to use the RunE field instead of Run, allowing errors to be returned directly for improved testability and proper execution of deferred functions.

Replaces the manual sync.WaitGroup and channel-based implementation in the `storage list` command with a `golang.org/x/sync/errgroup`. Simplifies the concurrent execution logic, improves error handling by immediately canceling sibling operations on the first error, and makes the code cleaner and easier to maintain.