### PR TITLE
refactor: Decouple provider resolution from command layer

### DIFF
--- a/cmd/synkronus/storage_cmd.go
+++ b/cmd/synkronus/storage_cmd.go
@@ -3,34 +3,43 @@ package main
 
 import (
 	"fmt"
-	"synkronus/internal/config"
+	"strings"
+	"synkronus/internal/provider"
 
 	"github.com/spf13/cobra"
 )
 
+type storageFlags struct {
+	providersList []string
+	provider      string
+	location      string
+}
+
 func newStorageCmd(app *appContainer) *cobra.Command {
-	var (
-		gcpProvider bool
-		awsProvider bool
-		location    string
-	)
+	flags := storageFlags{}
 
 	storageCmd := &cobra.Command{
 		Use:   "storage",
 		Short: "Manage storage resources like buckets",
-		Long:  `The storage command allows you to list, describe, create, and delete storage buckets from configured cloud providers like AWS and GCP.`,
+		Long:  `The storage command allows you to list, describe, create, and delete storage buckets from configured cloud providers.`,
 	}
 
-	storageCmd.PersistentFlags().BoolVar(&gcpProvider, "gcp", false, "Use GCP provider")
-	storageCmd.PersistentFlags().BoolVar(&awsProvider, "aws", false, "Use AWS provider")
+	const (
+		providerFlag  = "provider"
+		providersFlag = "providers"
+		locationFlag  = "location"
+	)
 
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List storage buckets",
-		Long:  `Lists all storage buckets from the configured cloud providers. Use flags to specify a provider.`,
+		Long: `Lists all storage buckets. If no flags are provided, it queries all configured providers. 
+Use the --providers flag to specify which providers to query (e.g., --providers gcp,aws).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Resolve which providers the user intends to query
-			providersToQuery := resolveProviders(gcpProvider, awsProvider, app.Config)
+			providersToQuery, err := resolveProvidersForList(flags.providersList, app.ProviderFactory)
+			if err != nil {
+				return err
+			}
 
 			allBuckets, err := app.StorageService.ListAllBuckets(cmd.Context(), providersToQuery)
 			if err != nil {
@@ -41,7 +50,7 @@ func newStorageCmd(app *appContainer) *cobra.Command {
 				fmt.Println(app.StorageFormatter.FormatBucketList(allBuckets))
 			} else {
 				if len(providersToQuery) == 0 {
-					fmt.Println("No providers configured or specified. Use 'synkronus config set' or provider flags (--gcp, --aws).")
+					fmt.Printf("No providers configured. Use 'synkronus config set'. Supported providers: %s\n", strings.Join(provider.GetSupportedProviders(), ", "))
 				} else {
 					fmt.Println("No buckets found.")
 				}
@@ -49,25 +58,16 @@ func newStorageCmd(app *appContainer) *cobra.Command {
 			return nil
 		},
 	}
+	listCmd.Flags().StringSliceVarP(&flags.providersList, providersFlag, "p", []string{}, "Specify providers to query (comma-separated). Defaults to all configured providers.")
 
 	describeCmd := &cobra.Command{
 		Use:   "describe [bucket-name]",
 		Short: "Describe a specific storage bucket",
-		Long:  `Provides detailed information about a specific storage bucket. You must specify the bucket name and the provider flag (--gcp or --aws).`,
+		Long:  `Provides detailed information about a specific storage bucket. You must specify the bucket name and the --provider flag.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bucketName := args[0]
-
-			if (!gcpProvider && !awsProvider) || (gcpProvider && awsProvider) {
-				return fmt.Errorf("you must specify exactly one provider flag (--gcp or --aws) for the describe command")
-			}
-
-			var providerName string
-			if gcpProvider {
-				providerName = "gcp"
-			} else {
-				providerName = "aws"
-			}
+			providerName := flags.provider
 
 			bucketDetails, err := app.StorageService.DescribeBucket(cmd.Context(), bucketName, providerName)
 			if err != nil {
@@ -78,56 +78,39 @@ func newStorageCmd(app *appContainer) *cobra.Command {
 			return nil
 		},
 	}
+	describeCmd.Flags().StringVarP(&flags.provider, providerFlag, "p", "", "The provider where the bucket resides (required)")
+	describeCmd.MarkFlagRequired(providerFlag)
 
 	createCmd := &cobra.Command{
 		Use:   "create [bucket-name]",
 		Short: "Create a new storage bucket",
-		Long:  `Creates a new storage bucket on the specified provider. You must specify the bucket name, a provider flag (--gcp or --aws), and the location/region flag (--location).`,
+		Long:  `Creates a new storage bucket on the specified provider. You must specify the bucket name, the --provider flag, and the --location flag.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bucketName := args[0]
-
-			if (!gcpProvider && !awsProvider) || (gcpProvider && awsProvider) {
-				return fmt.Errorf("you must specify exactly one provider flag (--gcp or --aws) for the create command")
-			}
-
-			var providerName string
-			if gcpProvider {
-				providerName = "gcp"
-			} else {
-				providerName = "aws"
-			}
-
-			err := app.StorageService.CreateBucket(cmd.Context(), bucketName, providerName, location)
+			providerName := flags.provider
+			err := app.StorageService.CreateBucket(cmd.Context(), bucketName, providerName, flags.location)
 			if err != nil {
 				return fmt.Errorf("error creating bucket '%s' on %s: %w", bucketName, providerName, err)
 			}
 
-			fmt.Printf("Bucket '%s' created successfully in %s on provider %s.\n", bucketName, location, providerName)
+			fmt.Printf("Bucket '%s' created successfully in %s on provider %s.\n", bucketName, flags.location, providerName)
 			return nil
 		},
 	}
-	createCmd.Flags().StringVar(&location, "location", "", "The location/region to create the bucket in (required)")
-	createCmd.MarkFlagRequired("location")
+	createCmd.Flags().StringVarP(&flags.provider, providerFlag, "p", "", "The provider to create the bucket on (required)")
+	createCmd.MarkFlagRequired(providerFlag)
+	createCmd.Flags().StringVarP(&flags.location, locationFlag, "l", "", "The location/region to create the bucket in (required)")
+	createCmd.MarkFlagRequired(locationFlag)
 
 	deleteCmd := &cobra.Command{
 		Use:   "delete [bucket-name]",
 		Short: "Delete a storage bucket",
-		Long:  `Deletes a storage bucket on the specified provider. You must specify the bucket name and a provider flag (--gcp or --aws).`,
+		Long:  `Deletes a storage bucket on the specified provider. You must specify the bucket name and the --provider flag.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bucketName := args[0]
-
-			if (!gcpProvider && !awsProvider) || (gcpProvider && awsProvider) {
-				return fmt.Errorf("you must specify exactly one provider flag (--gcp or --aws) for the delete command")
-			}
-
-			var providerName string
-			if gcpProvider {
-				providerName = "gcp"
-			} else {
-				providerName = "aws"
-			}
+			providerName := flags.provider
 
 			err := app.StorageService.DeleteBucket(cmd.Context(), bucketName, providerName)
 			if err != nil {
@@ -138,42 +121,44 @@ func newStorageCmd(app *appContainer) *cobra.Command {
 			return nil
 		},
 	}
+	deleteCmd.Flags().StringVarP(&flags.provider, providerFlag, "p", "", "The provider where the bucket resides (required)")
+	deleteCmd.MarkFlagRequired(providerFlag)
 
 	storageCmd.AddCommand(listCmd, describeCmd, createCmd, deleteCmd)
 	return storageCmd
 }
 
-// Determines the list of provider names based on CLI flags and configuration
-func resolveProviders(useGCP, useAWS bool, cfg *config.Config) []string {
-	var providersToQuery []string
-
-	// Determine intent based on flags
-	onlyGCP := useGCP && !useAWS
-	onlyAWS := useAWS && !useGCP
-	// If no flags are provided, the default is to query all configured providers
-	noFlags := !useGCP && !useAWS
-
-	if onlyGCP {
-		return append(providersToQuery, "gcp")
+func resolveProvidersForList(requestedProviders []string, factory *provider.Factory) ([]string, error) {
+	if len(requestedProviders) == 0 {
+		return factory.GetConfiguredProviders(), nil
 	}
 
-	if onlyAWS {
-		return append(providersToQuery, "aws")
+	var validatedProviders []string
+	var invalidProviders []string
+	seen := make(map[string]bool)
+
+	for _, p := range requestedProviders {
+		p = strings.ToLower(strings.TrimSpace(p))
+
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+
+		if provider.IsSupported(p) {
+			if factory.IsConfigured(p) {
+				validatedProviders = append(validatedProviders, p)
+			} else {
+				return nil, fmt.Errorf("provider '%s' was requested but is not configured. Use 'synkronus config set %s.<key> <value>'", p, p)
+			}
+		} else {
+			invalidProviders = append(invalidProviders, p)
+		}
 	}
 
-	// Requesting both (explicitly via --gcp and --aws) or implicitly (via no flags)
-	gcpConfigured := cfg.GCP != nil && cfg.GCP.Project != ""
-	awsConfigured := cfg.AWS != nil && cfg.AWS.Region != ""
-
-	// Include GCP if explicitly requested OR if no flags were set AND GCP is configured
-	if useGCP || (noFlags && gcpConfigured) {
-		providersToQuery = append(providersToQuery, "gcp")
+	if len(invalidProviders) > 0 {
+		return nil, fmt.Errorf("unsupported providers requested: %v. Supported providers are: %v", invalidProviders, provider.GetSupportedProviders())
 	}
 
-	// Include AWS if explicitly requested OR if no flags were set AND AWS is configured
-	if useAWS || (noFlags && awsConfigured) {
-		providersToQuery = append(providersToQuery, "aws")
-	}
-
-	return providersToQuery
+	return validatedProviders, nil
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,0 +1,19 @@
+// File: internal/flags/flags.go
+package flags
+
+// Centralized definitions for CLI flags used across the application
+
+const (
+	// Provider flags are used when an operation targets a single, specific provider (e.g., describe, create, delete)
+	Provider      = "provider"
+	ProviderShort = "p"
+
+	// Providers (plural) flags are used when an operation can target multiple providers (e.g., list)
+	// Note: In this application, 'p' is reused for both singular and plural provider flags depending on the subcommand context
+	Providers      = "providers"
+	ProvidersShort = "p"
+
+	// Location flags are used to specify the geographical location or region for resource creation.
+	Location      = "location"
+	LocationShort = "l"
+)

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 	"synkronus/internal/config"
 	"synkronus/pkg/storage"
 	"synkronus/pkg/storage/aws"
@@ -23,21 +25,43 @@ func NewFactory(cfg *config.Config, logger *slog.Logger) *Factory {
 	}
 }
 
-func (f *Factory) GetStorageProvider(ctx context.Context, providerName string) (storage.Storage, error) {
-	providerLogger := f.logger.With("provider", providerName)
-
-	switch providerName {
-	case "gcp":
-		if f.cfg.GCP == nil || f.cfg.GCP.Project == "" {
-			return nil, fmt.Errorf("GCP project not configured. Use 'synkronus config set gcp.project <project-id>'")
+func (f *Factory) GetConfiguredProviders() []string {
+	var configuredProviders []string
+	for name, check := range providerRegistry {
+		if check(f.cfg) {
+			configuredProviders = append(configuredProviders, name)
 		}
+	}
+	sort.Strings(configuredProviders)
+	return configuredProviders
+}
+
+func (f *Factory) IsConfigured(providerName string) bool {
+	check, exists := getConfigurationCheck(providerName)
+	if !exists {
+		return false
+	}
+	return check(f.cfg)
+}
+
+func (f *Factory) GetStorageProvider(ctx context.Context, providerName string) (storage.Storage, error) {
+	normalizedName := strings.ToLower(providerName)
+	providerLogger := f.logger.With("provider", normalizedName)
+
+	if !IsSupported(normalizedName) {
+		return nil, fmt.Errorf("unsupported provider: %s. Supported providers are: %v", providerName, GetSupportedProviders())
+	}
+
+	if !f.IsConfigured(normalizedName) {
+		return nil, fmt.Errorf("provider '%s' is not configured. Use 'synkronus config set %s.<key> <value>' (e.g., 'gcp.project' or 'aws.region')", normalizedName, normalizedName)
+	}
+
+	switch normalizedName {
+	case "gcp":
 		return gcp.NewGCPStorage(ctx, f.cfg.GCP.Project, providerLogger)
 	case "aws":
-		if f.cfg.AWS == nil || f.cfg.AWS.Region == "" {
-			return nil, fmt.Errorf("AWS region not configured. Use 'synkronus config set aws.region <region>'")
-		}
 		return aws.NewAWSStorage(f.cfg.AWS.Region, providerLogger), nil
 	default:
-		return nil, fmt.Errorf("unsupported provider: %s", providerName)
+		return nil, fmt.Errorf("internal error: provider %s supported but not implemented in factory", normalizedName)
 	}
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,38 @@
+// File: internal/provider/registry.go
+package provider
+
+import (
+	"sort"
+	"strings"
+	"synkronus/internal/config"
+)
+
+type ProviderConfigCheck func(cfg *config.Config) bool
+
+var providerRegistry = map[string]ProviderConfigCheck{
+	"gcp": func(cfg *config.Config) bool {
+		return cfg.GCP != nil && cfg.GCP.Project != ""
+	},
+	"aws": func(cfg *config.Config) bool {
+		return cfg.AWS != nil && cfg.AWS.Region != ""
+	},
+}
+
+func GetSupportedProviders() []string {
+	providers := make([]string, 0, len(providerRegistry))
+	for name := range providerRegistry {
+		providers = append(providers, name)
+	}
+	sort.Strings(providers)
+	return providers
+}
+
+func IsSupported(providerName string) bool {
+	_, exists := providerRegistry[strings.ToLower(providerName)]
+	return exists
+}
+
+func getConfigurationCheck(providerName string) (ProviderConfigCheck, bool) {
+	check, exists := providerRegistry[strings.ToLower(providerName)]
+	return check, exists
+}


### PR DESCRIPTION
Refactors the provider resolution logic to dynamically detect configured providers from the configuration. This removes hardcoded checks in the storage and config commands, making it easier to add new providers in the future by adhering to the [Open/Closed Principle](https://www.freecodecamp.org/news/open-closed-principle-solid-architecture-concept-explained/)