### PR TITLE
feat(cli): Implement type-to-confirm prompt for destructive operations

### DIFF
--- a/cmd/synkronus/app.go
+++ b/cmd/synkronus/app.go
@@ -3,9 +3,11 @@ package main
 
 import (
 	"log/slog"
+	"os"
 	"synkronus/internal/config"
 	"synkronus/internal/provider/factory"
 	"synkronus/internal/service"
+	"synkronus/internal/ui/prompt"
 	"synkronus/pkg/formatter"
 )
 
@@ -17,6 +19,7 @@ type appContainer struct {
 	ProviderFactory  *factory.Factory
 	StorageService   *service.StorageService
 	StorageFormatter *formatter.StorageFormatter
+	Prompter         prompt.Prompter
 	Logger           *slog.Logger
 }
 
@@ -36,12 +39,15 @@ func newApp(logger *slog.Logger) (*appContainer, error) {
 	storageService := service.NewStorageService(providerFactory, logger)
 	storageFormatter := formatter.NewStorageFormatter()
 
+	prompter := prompt.NewStandardPrompter(os.Stdin, os.Stdout)
+
 	return &appContainer{
 		Config:           cfg,
 		ConfigManager:    cfgManager,
 		ProviderFactory:  providerFactory,
 		StorageService:   storageService,
 		StorageFormatter: storageFormatter,
+		Prompter:         prompter,
 		Logger:           logger,
 	}, nil
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -16,4 +16,8 @@ const (
 	// Location flags are used to specify the geographical location or region for resource creation.
 	Location      = "location"
 	LocationShort = "l"
+
+	// Force flags are used to bypass interactive confirmation prompts for destructive operations
+	Force      = "force"
+	ForceShort = "f"
 )

--- a/internal/ui/prompt/prompt.go
+++ b/internal/ui/prompt/prompt.go
@@ -1,0 +1,52 @@
+// File: internal/ui/prompt/prompt.go
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Defines the interface for prompting the user for input
+type Prompter interface {
+	// Asks the user for confirmation by requiring them to type a specific expected value
+	Confirm(message string, expectedValue string) (bool, error)
+}
+
+// Provides a standard implementation of the Prompter interface using specified input/output streams
+type StandardPrompter struct {
+	reader io.Reader
+	writer io.Writer
+}
+
+// Creates a new StandardPrompter with the given input and output streams
+func NewStandardPrompter(in io.Reader, out io.Writer) *StandardPrompter {
+	return &StandardPrompter{
+		reader: in,
+		writer: out,
+	}
+}
+
+// Asks the user for confirmation by requiring them to type a specific expected value
+func (p *StandardPrompter) Confirm(message string, expectedValue string) (bool, error) {
+	if expectedValue == "" {
+		return false, fmt.Errorf("expected confirmation value cannot be empty")
+	}
+
+	fmt.Fprintln(p.writer, message)
+	fmt.Fprintf(p.writer, "To confirm, please type the name '%s': ", expectedValue)
+
+	reader := bufio.NewReader(p.reader)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		if err == io.EOF {
+			return false, nil
+		}
+		return false, fmt.Errorf("error reading user input: %w", err)
+	}
+
+	cleanedInput := strings.TrimSpace(input)
+
+	return cleanedInput == expectedValue, nil
+}


### PR DESCRIPTION
Introduces a reusable interactive prompt utility requiring users to type the resource name to confirm destructive actions (starting with `storage delete`). Includes a `--force` flag to bypass the prompt for automation