### PR TITLE
feat(storage): Integrate GCP IAM policies into `storage describe`

### DIFF
--- a/pkg/storage/gcp/buckets.go
+++ b/pkg/storage/gcp/buckets.go
@@ -116,18 +116,17 @@ func (g *GCPStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 	return details, nil
 }
 
-// Fetches the bucket's IAM policy and maps it to the domain model
+// Fetches the bucket's IAM policy (using V3) and maps it to the domain model
 func (g *GCPStorage) getIAMPolicy(ctx context.Context, bucketHandle *gcpstorage.BucketHandle) (*storage.IAMPolicy, error) {
-	policy, err := bucketHandle.IAM().Policy(ctx)
+	policy, err := bucketHandle.IAM().V3().Policy(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get IAM policy: %w", err)
+		return nil, fmt.Errorf("failed to get V3 IAM policy: %w", err)
 	}
 
-	// Map the SDK policy structure (which handles V1/V3) to the domain model
+	// Map the SDK V3 policy structure to the domain model
 	var bindings []storage.IAMBinding
 	hasConditions := false
 
-	// Iterate over the Bindings field directly for the most accurate representation
 	for _, binding := range policy.Bindings {
 		// Skip bindings with conditions as they complicate the CLI view and are not yet supported in the detailed model
 		// TODO: add support for conditional bindings in the future

--- a/pkg/storage/gcp/buckets.go
+++ b/pkg/storage/gcp/buckets.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"synkronus/pkg/common"
 	"synkronus/pkg/storage"
 
@@ -87,6 +88,12 @@ func (g *GCPStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 		g.logger.Warn("Could not retrieve ACLs for bucket", "bucket", bucketName, "error", err)
 	}
 
+	// Fetch IAM Policy (separate API call)
+	iamPolicy, err := g.getIAMPolicy(ctx, bucketHandle)
+	if err != nil {
+		g.logger.Warn("Could not retrieve IAM policy for bucket. Requires 'storage.buckets.getIamPolicy' permission.", "bucket", bucketName, "error", err)
+	}
+
 	details := storage.Bucket{
 		Name:                     attrs.Name,
 		Provider:                 common.GCP,
@@ -96,6 +103,7 @@ func (g *GCPStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 		UpdatedAt:                attrs.Updated,
 		UsageBytes:               usage,
 		Labels:                   attrs.Labels,
+		IAMPolicy:                iamPolicy,
 		ACLs:                     aclRules,
 		LifecycleRules:           mapLifecycleRules(attrs.Lifecycle.Rules),
 		Logging:                  mapLogging(attrs.Logging),
@@ -108,11 +116,55 @@ func (g *GCPStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 	return details, nil
 }
 
+// Fetches the bucket's IAM policy and maps it to the domain model
+func (g *GCPStorage) getIAMPolicy(ctx context.Context, bucketHandle *gcpstorage.BucketHandle) (*storage.IAMPolicy, error) {
+	policy, err := bucketHandle.IAM().Policy(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get IAM policy: %w", err)
+	}
+
+	// Map the SDK policy structure (which handles V1/V3) to the domain model
+	var bindings []storage.IAMBinding
+	hasConditions := false
+
+	// Iterate over the Bindings field directly for the most accurate representation
+	for _, binding := range policy.Bindings {
+		// Skip bindings with conditions as they complicate the CLI view and are not yet supported in the detailed model
+		// TODO: add support for conditional bindings in the future
+		if binding.Condition != nil {
+			g.logger.Debug("Skipping conditional IAM binding", "role", binding.Role, "condition", binding.Condition.Title)
+			hasConditions = true
+			continue
+		}
+
+		// Ensure principals are sorted for deterministic output
+		principals := make([]string, len(binding.Members))
+		copy(principals, binding.Members)
+		sort.Strings(principals)
+
+		bindings = append(bindings, storage.IAMBinding{
+			Role:       binding.Role,
+			Principals: principals,
+		})
+	}
+
+	// Sort bindings by role name for deterministic output
+	sort.Slice(bindings, func(i, j int) bool {
+		return bindings[i].Role < bindings[j].Role
+	})
+
+	return &storage.IAMPolicy{
+		Bindings:      bindings,
+		HasConditions: hasConditions,
+	}, nil
+}
+
 // getACLs fetches the bucket's ACLs
 func (g *GCPStorage) getACLs(ctx context.Context, bucketHandle *gcpstorage.BucketHandle) ([]storage.ACLRule, error) {
 	gcpAcls, err := bucketHandle.ACL().List(ctx)
 	if err != nil {
 		var gcsErr *googleapi.Error
+		// If UBLA is enabled, GCP returns a 400 error when trying to list ACLs (treating as expected behavior)
 		if errors.As(err, &gcsErr) && gcsErr.Code == 400 {
 			return []storage.ACLRule{}, nil
 		}

--- a/pkg/storage/gcp/buckets.go
+++ b/pkg/storage/gcp/buckets.go
@@ -88,16 +88,15 @@ func (g *GCPStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 	}
 
 	details := storage.Bucket{
-		Name:         attrs.Name,
-		Provider:     common.GCP,
-		Location:     attrs.Location,
-		StorageClass: attrs.StorageClass,
-		CreatedAt:    attrs.Created,
-		UpdatedAt:    attrs.Updated,
-		UsageBytes:   usage,
-		Labels:       attrs.Labels,
-		ACLs:         aclRules,
-		// Mapping functions are called from mappers.go
+		Name:                     attrs.Name,
+		Provider:                 common.GCP,
+		Location:                 attrs.Location,
+		StorageClass:             attrs.StorageClass,
+		CreatedAt:                attrs.Created,
+		UpdatedAt:                attrs.Updated,
+		UsageBytes:               usage,
+		Labels:                   attrs.Labels,
+		ACLs:                     aclRules,
 		LifecycleRules:           mapLifecycleRules(attrs.Lifecycle.Rules),
 		Logging:                  mapLogging(attrs.Logging),
 		Versioning:               &storage.Versioning{Enabled: attrs.VersioningEnabled},

--- a/pkg/storage/model.go
+++ b/pkg/storage/model.go
@@ -18,6 +18,7 @@ type Bucket struct {
 	UsageBytes int64
 	Labels     map[string]string
 
+	IAMPolicy                *IAMPolicy
 	ACLs                     []ACLRule
 	LifecycleRules           []LifecycleRule
 	Logging                  *Logging
@@ -42,6 +43,20 @@ type SoftDeletePolicy struct {
 
 type UniformBucketLevelAccess struct {
 	Enabled bool
+}
+
+// Represents the IAM policy attached to a resource
+type IAMPolicy struct {
+	// Associates a list of principals with a role
+	Bindings []IAMBinding
+	// Indicates if the policy contains conditional bindings that are not displayed
+	HasConditions bool
+}
+
+// Represents a single binding in an IAM policy
+type IAMBinding struct {
+	Role       string
+	Principals []string
 }
 
 type ACLRule struct {


### PR DESCRIPTION
Integrates Google Cloud IAM policy retrieval and visualization into the `storage describe` command to provide a comprehensive security overview.