### PR TITLE
feat(storage): Display Requester Pays status in bucket details

### DIFF
--- a/pkg/formatter/storage_formatter.go
+++ b/pkg/formatter/storage_formatter.go
@@ -61,6 +61,15 @@ func (f *StorageFormatter) formatOverviewSection(bucket storage.Bucket) string {
 	overviewTable.AddRow([]string{"Location / Region", bucket.Location})
 	overviewTable.AddRow([]string{"Default Storage Class", bucket.StorageClass})
 	overviewTable.AddRow([]string{"Usage (Total Bytes)", storage.FormatBytes(bucket.UsageBytes)})
+
+	requesterPaysStatus := "Disabled"
+	if bucket.RequesterPays {
+		requesterPaysStatus = "Enabled"
+	}
+	if bucket.Provider == common.GCP {
+		overviewTable.AddRow([]string{"Requester Pays", requesterPaysStatus})
+	}
+
 	overviewTable.AddRow([]string{"Created On", bucket.CreatedAt.Format(time.RFC1123)})
 	overviewTable.AddRow([]string{"Updated On", bucket.UpdatedAt.Format(time.RFC1123)})
 

--- a/pkg/storage/gcp/buckets.go
+++ b/pkg/storage/gcp/buckets.go
@@ -102,6 +102,7 @@ func (g *GCPStorage) DescribeBucket(ctx context.Context, bucketName string) (sto
 		CreatedAt:                attrs.Created,
 		UpdatedAt:                attrs.Updated,
 		UsageBytes:               usage,
+		RequesterPays:            attrs.RequesterPays,
 		Labels:                   attrs.Labels,
 		IAMPolicy:                iamPolicy,
 		ACLs:                     aclRules,

--- a/pkg/storage/model.go
+++ b/pkg/storage/model.go
@@ -15,8 +15,9 @@ type Bucket struct {
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	// A value of -1 indicates that the usage is unknown or could not be retrieved
-	UsageBytes int64
-	Labels     map[string]string
+	UsageBytes    int64
+	RequesterPays bool
+	Labels        map[string]string
 
 	IAMPolicy                *IAMPolicy
 	ACLs                     []ACLRule


### PR DESCRIPTION
Enhances the 'storage describe' command by adding the `Requester Pays` status to the overview section for better cost management visibility by clearly indicating whether the bucket owner or the requester pays for data access charges