### PR TITLE
feat: Implement configurable logging verbosity via --debug flag

### DIFF
--- a/cmd/synkronus/app.go
+++ b/cmd/synkronus/app.go
@@ -2,14 +2,22 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"synkronus/internal/config"
+	"synkronus/internal/logger"
 	"synkronus/internal/provider/factory"
 	"synkronus/internal/service"
 	"synkronus/internal/ui/prompt"
 	"synkronus/pkg/formatter"
 )
+
+// Defines a specific type for the context key to avoid collisions
+type contextKey string
+
+const appContextKey contextKey = "appContainer"
 
 // appContainer holds all the shared dependencies for the application
 // This includes configuration, service clients, formatters, and the logger
@@ -23,22 +31,32 @@ type appContainer struct {
 	Logger           *slog.Logger
 }
 
-// Creates and initializes a new application container
-func newApp(logger *slog.Logger) (*appContainer, error) {
+// Creates and initializes a new application container based on the debug mode setting
+func newApp(debugMode bool) (*appContainer, error) {
+	// 1. Initialize the logger first, as it's required by other components
+	logLevel := slog.LevelInfo
+	if debugMode {
+		logLevel = slog.LevelDebug
+	}
+	log := logger.NewLogger(logLevel)
+
+	// 2. Load configuration
 	cfgManager, err := config.NewConfigManager()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize config manager: %w", err)
 	}
 
 	cfg, err := cfgManager.LoadConfig()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	providerFactory := factory.NewFactory(cfg, logger)
-	storageService := service.NewStorageService(providerFactory, logger)
+	// 3. Initialize factories and services
+	providerFactory := factory.NewFactory(cfg, log)
+	storageService := service.NewStorageService(providerFactory, log)
 	storageFormatter := formatter.NewStorageFormatter()
 
+	// 4. Initialize UI components
 	prompter := prompt.NewStandardPrompter(os.Stdin, os.Stdout)
 
 	return &appContainer{
@@ -48,6 +66,20 @@ func newApp(logger *slog.Logger) (*appContainer, error) {
 		StorageService:   storageService,
 		StorageFormatter: storageFormatter,
 		Prompter:         prompter,
-		Logger:           logger,
+		Logger:           log,
 	}, nil
+}
+
+// Injects the application container into the given context
+func (a *appContainer) ToContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, appContextKey, a)
+}
+
+// Retrieves the application container from the context
+func appFromContext(ctx context.Context) (*appContainer, error) {
+	app, ok := ctx.Value(appContextKey).(*appContainer)
+	if !ok {
+		return nil, fmt.Errorf("application container not found in context")
+	}
+	return app, nil
 }

--- a/cmd/synkronus/config_cmd.go
+++ b/cmd/synkronus/config_cmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newConfigCmd(app *appContainer) *cobra.Command {
+func newConfigCmd() *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage configuration settings",
@@ -22,6 +22,11 @@ func newConfigCmd(app *appContainer) *cobra.Command {
 		Long:  `Sets a configuration value. For example: 'synkronus config set gcp.project my-gcp-123'`,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			key := strings.ToLower(args[0])
 			value := args[1]
 
@@ -39,6 +44,11 @@ func newConfigCmd(app *appContainer) *cobra.Command {
 		Long:  `Retrieves a configuration value for a given key. For example: 'synkronus config get gcp.project'`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			key := strings.ToLower(args[0])
 			value, exists := app.ConfigManager.GetValue(key)
 
@@ -56,6 +66,11 @@ func newConfigCmd(app *appContainer) *cobra.Command {
 		Long:  `Deletes a configuration value for a given key. For example: 'synkronus config delete gcp.project'`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			key := strings.ToLower(args[0])
 			deleted, err := app.ConfigManager.DeleteValue(key)
 
@@ -76,6 +91,11 @@ func newConfigCmd(app *appContainer) *cobra.Command {
 		Short: "List all current configuration values",
 		Long:  `Displays all the key-value pairs currently stored in the configuration.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			settings := app.ConfigManager.GetAllSettings()
 			flattenedSettings := flattenConfigMap(settings)
 

--- a/cmd/synkronus/main.go
+++ b/cmd/synkronus/main.go
@@ -2,21 +2,13 @@
 package main
 
 import (
-	"os"
-	"synkronus/internal/logger"
-
 	// Explicitly import provider implementations to ensure their init() functions run and they register themselves
 	_ "synkronus/pkg/storage/aws"
 	_ "synkronus/pkg/storage/gcp"
 )
 
 func main() {
-	log := logger.NewLogger()
-
-	app, err := newApp(log)
-	if err != nil {
-		log.Error("Failed to initialize application", "error", err)
-		os.Exit(1)
-	}
-	Execute(app)
+	// The application container (including the logger) is initialized within the root command's
+	// PersistentPreRunE hook, ensuring flags (like --debug) are parsed first
+	Execute()
 }

--- a/cmd/synkronus/root.go
+++ b/cmd/synkronus/root.go
@@ -2,32 +2,63 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"synkronus/internal/flags"
 
 	"github.com/spf13/cobra"
 )
 
-// Creates the root command and wires up its subcommands using
-// the application container for dependency injection
-func newRootCmd(app *appContainer) *cobra.Command {
+// Creates the root command, defines global flags, and sets up the initialization hook
+func newRootCmd() *cobra.Command {
+	var debugMode bool
+
 	cmd := &cobra.Command{
 		Use:   "synkronus",
 		Short: "Synkronus is a command-line tool for managing cloud resources.",
 		Long: `A unified CLI to interact with various cloud services for resources
 like storage, SQL databases, and more. Configure your providers and
 manage your infrastructure from one place.`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Initialize the application container
+			app, err := newApp(debugMode)
+			if err != nil {
+				return fmt.Errorf("failed to initialize application: %w", err)
+			}
+
+			if debugMode {
+				app.Logger.Debug("Debug logging enabled")
+			}
+
+			// Inject the initialized container into the command's context
+			// so subcommands can access it
+			ctx := app.ToContext(cmd.Context())
+			cmd.SetContext(ctx)
+
+			return nil
+		},
+		// Silence usage on error, error reporting is explicitly handled in Execute()
+		SilenceUsage: true,
+		// Silence errors so we don't print the error twice (once by Cobra, once Execute())
+		SilenceErrors: true,
 	}
 
-	cmd.AddCommand(newStorageCmd(app))
-	cmd.AddCommand(newConfigCmd(app))
+	// Define persistent flags (available to all subcommands)
+	cmd.PersistentFlags().BoolVarP(&debugMode, flags.Debug, flags.DebugShort, false, "Enable verbose debug logging")
+
+	// Add subcommands
+	cmd.AddCommand(newStorageCmd())
+	cmd.AddCommand(newConfigCmd())
 	cmd.AddCommand(newSqlCmd())
 
 	return cmd
 }
 
-func Execute(app *appContainer) {
-	rootCmd := newRootCmd(app)
+// Starts the CLI execution
+func Execute() {
+	rootCmd := newRootCmd()
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/synkronus/sql_cmd.go
+++ b/cmd/synkronus/sql_cmd.go
@@ -18,6 +18,13 @@ func newSqlCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List SQL resources",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Retrieve the app container to access services and configuration if needed
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			app.Logger.Debug("Executing SQL list command (Placeholder)")
 			fmt.Println("Listing SQL resources...")
 			// TODO: Implement SQL listing functionality
 			return nil

--- a/cmd/synkronus/storage_cmd.go
+++ b/cmd/synkronus/storage_cmd.go
@@ -22,7 +22,7 @@ type storageFlags struct {
 	force         bool
 }
 
-func newStorageCmd(app *appContainer) *cobra.Command {
+func newStorageCmd() *cobra.Command {
 	cmdFlags := storageFlags{}
 
 	storageCmd := &cobra.Command{
@@ -37,6 +37,11 @@ func newStorageCmd(app *appContainer) *cobra.Command {
 		Long: `Lists all storage buckets. If no flags are provided, it queries all configured providers. 
 Use the --providers flag to specify which providers to query (e.g., --providers gcp,aws).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			providersToQuery, err := resolveProvidersForList(cmdFlags.providersList, app.ProviderFactory)
 			if err != nil {
 				return err
@@ -67,6 +72,11 @@ Use the --providers flag to specify which providers to query (e.g., --providers 
 		Long:  `Provides detailed information about a specific storage bucket. You must specify the bucket name and the --provider flag.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			bucketName := args[0]
 			providerName := cmdFlags.provider
 
@@ -88,9 +98,14 @@ Use the --providers flag to specify which providers to query (e.g., --providers 
 		Long:  `Creates a new storage bucket on the specified provider. You must specify the bucket name, the --provider flag, and the --location flag.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			bucketName := args[0]
 			providerName := cmdFlags.provider
-			err := app.StorageService.CreateBucket(cmd.Context(), bucketName, providerName, cmdFlags.location)
+			err = app.StorageService.CreateBucket(cmd.Context(), bucketName, providerName, cmdFlags.location)
 			if err != nil {
 				return fmt.Errorf("error creating bucket '%s' on %s: %w", bucketName, providerName, err)
 			}
@@ -111,6 +126,11 @@ Use the --providers flag to specify which providers to query (e.g., --providers 
 Confirmation is required by typing the bucket name, unless the --force flag is used.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appFromContext(cmd.Context())
+			if err != nil {
+				return err
+			}
+
 			bucketName := args[0]
 			providerName := cmdFlags.provider
 
@@ -127,7 +147,7 @@ Confirmation is required by typing the bucket name, unless the --force flag is u
 				}
 			}
 
-			err := app.StorageService.DeleteBucket(cmd.Context(), bucketName, providerName)
+			err = app.StorageService.DeleteBucket(cmd.Context(), bucketName, providerName)
 			if err != nil {
 				return fmt.Errorf("error deleting bucket '%s' on %s: %w", bucketName, providerName, err)
 			}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -20,4 +20,8 @@ const (
 	// Force flags are used to bypass interactive confirmation prompts for destructive operations
 	Force      = "force"
 	ForceShort = "f"
+
+	// Debug flags are used to enable verbose logging
+	Debug      = "debug"
+	DebugShort = "d"
 )

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -6,10 +6,9 @@ import (
 	"os"
 )
 
-func NewLogger() *slog.Logger {
-	// TODO: Allow configuring log level (e.g., Debug) via environment variables or flags
+func NewLogger(level slog.Level) *slog.Logger {
 	opts := &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: level,
 	}
 
 	handler := slog.NewTextHandler(os.Stdout, opts)


### PR DESCRIPTION
Implements a persistent `--debug` flag to control the global `slog` level. Also refactored the application initialization to use Cobra's `PersistentPreRunE` hook and context-based dependency injection, ensuring the logger is correctly configured before subcommands execute.